### PR TITLE
fix(cd): Align CD workflow with actual K8s configuration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,9 +11,9 @@ on:
 
 env:
   NODE_VERSION: '20'
-  REGISTRY: localhost:5000  # 本地 registry，可改為 Docker Hub 或其他
-  IMAGE_NAME: frontend
-  K8S_NAMESPACE: default
+  REGISTRY: localhost  # 本地 podman registry
+  IMAGE_NAME: wisdon-frontend
+  K8S_NAMESPACE: wisdon-frontend
 
 jobs:
   build-and-push:
@@ -45,10 +45,11 @@ jobs:
             --label "git.branch=${{ github.ref_name }}" \
             .
 
-      - name: Push to registry
+      - name: Verify image built
         run: |
-          podman push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
-          podman push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          # K8s 使用 imagePullPolicy: Never，直接使用本地 podman image
+          podman images | grep ${{ env.IMAGE_NAME }} | head -5
+          echo "✅ Image built successfully: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"
 
   deploy:
     name: Deploy to K8s
@@ -62,20 +63,20 @@ jobs:
       - name: Update K8s deployment
         run: |
           # 更新 deployment 使用新的 image
-          kubectl set image deployment/frontend-deployment \
+          kubectl set image deployment/frontend \
             frontend=${{ needs.build-and-push.outputs.full_image }} \
             -n ${{ env.K8S_NAMESPACE }}
 
       - name: Wait for rollout
         run: |
-          kubectl rollout status deployment/frontend-deployment \
+          kubectl rollout status deployment/frontend \
             -n ${{ env.K8S_NAMESPACE }} \
             --timeout=300s
 
       - name: Verify deployment
         run: |
           echo "=== Deployment Status ==="
-          kubectl get deployment frontend-deployment -n ${{ env.K8S_NAMESPACE }}
+          kubectl get deployment frontend -n ${{ env.K8S_NAMESPACE }}
           echo ""
           echo "=== Pod Status ==="
           kubectl get pods -n ${{ env.K8S_NAMESPACE }} -l app=frontend


### PR DESCRIPTION
## Summary

修正 CD workflow 的配置以對應實際的 K8s 部署設定：

- 將 `K8S_NAMESPACE` 從 `default` 改為 `wisdon-frontend`
- 將 `IMAGE_NAME` 改為 `wisdon-frontend` 以匹配 K8s deployment
- 將 deployment 名稱從 `frontend-deployment` 改為 `frontend`
- 移除 push to registry 步驟（K8s 使用 `imagePullPolicy: Never`，直接使用本地 podman image）
- 新增 image verification 步驟

## 相關問題

CD workflow 中的配置與實際 K8s 設定不符：

| 原 cd.yml 設定 | 實際 K8s 設定 |
|-------------|---------------|
| `K8S_NAMESPACE: default` | `wisdon-frontend` |
| `frontend-deployment` | `frontend` |
| `localhost:5000` registry | `localhost/wisdon-frontend` |

## Test plan

- [ ] CI 測試通過
- [ ] 合併後確認 CD workflow 正確觸發
- [ ] 確認 K8s deployment 正確更新