### PR TITLE
security(k8s): Harden frontend deployment configuration

### DIFF
--- a/k8s/frontend/deployment.yaml
+++ b/k8s/frontend/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: frontend
 spec:
   replicas: 1
+  revisionHistoryLimit: 3  # 限制保留的舊版本數量
   selector:
     matchLabels:
       app: frontend
@@ -25,7 +26,7 @@ spec:
           imagePullPolicy: Never
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true  # 生產環境安全設定
             capabilities:
               drop:
                 - ALL
@@ -58,4 +59,14 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: data
+              mountPath: /app/.data
       restartPolicy: Always
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
## Summary

強化 K8s 前端部署的安全設定：

- `revisionHistoryLimit: 3` - 限制舊 ReplicaSet 數量，避免堆積
- `readOnlyRootFilesystem: true` - 容器檔案系統唯讀（生產環境安全標準）
- 新增 emptyDir volumes (`/tmp`, `/app/.data`) - 唯讀檔案系統必需的可寫目錄

## 安全檢查清單

- [x] `readOnlyRootFilesystem: true`
- [x] `allowPrivilegeEscalation: false`
- [x] `capabilities.drop: ["ALL"]`
- [x] `runAsNonRoot: true`
- [x] `runAsUser: 1000`

## Test plan

- [x] 當前 K8s 已套用這些設定並正常運行
- [ ] CI 通過